### PR TITLE
Add Sad Path For Forecast

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,11 +1,21 @@
 class Api::V1::ForecastController < ApplicationController
   def index
     coordinates = Location.info(forecast_params[:location])
-    forecast = Forecast.get_info(coordinates)
-    render json: ForecastSerializer.new(forecast)
+    if coordinates
+      forecast = Forecast.get_info(coordinates)
+      render json: ForecastSerializer.new(forecast)
+    else
+      error
+    end
   end
 
   def forecast_params
     params.permit(:location)
+  end
+
+  def error
+    data = { errors: [] }
+    data[:errors] << { id: 'location', title: 'invalid location' }
+    render json: data, status: :unprocessable_entity
   end
 end

--- a/app/poros/location.rb
+++ b/app/poros/location.rb
@@ -9,6 +9,8 @@ class Location
 
   def self.info(location)
     response = GoogleService.new.geocode_info(location)
+    return if response[:results].empty?
+
     location_info = response[:results].first
     info = { title: location_info[:formatted_address],
              lat: location_info[:geometry][:location][:lat],

--- a/spec/api/v1/forecast_request_spec.rb
+++ b/spec/api/v1/forecast_request_spec.rb
@@ -58,4 +58,13 @@ describe "API V1" do
     expect(data).to have_key :hourly
     expect(data).to have_key :daily
   end
+  it "returns error status", :vcr do
+    get '/api/v1/forecast?location=1111111'
+
+    expect(response).to_not be_successful
+    json = JSON.parse(response.body, symbolize_names: true)
+    data = json[:errors].first
+    expect(data).to have_key :id
+    expect(data).to have_key :title
+  end
 end

--- a/spec/fixtures/vcr_cassettes/API_V1/returns_error_status.yml
+++ b/spec/fixtures/vcr_cassettes/API_V1/returns_error_status.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1111111&key=<GOOGLE_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 08 Jun 2020 14:48:33 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=188
+      Alt-Svc:
+      - h3-27=":443"; ma=2592000,h3-25=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q050=":443";
+        ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [],
+           "status" : "ZERO_RESULTS"
+        }
+  recorded_at: Mon, 08 Jun 2020 14:48:33 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## What functionality does this accomplish?
- Add sad path testing for forecast API

## Testing
### RSpec: 15 examples, 0 failures
### SimpleCov Coverage: 100.0%
### Rubocop:
- [x] No offenses
## Resources:
- https://jsonapi.org/
- https://jsonapi-validator.herokuapp.com/