### PR TITLE
Fix Time-based Testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'puma', '~> 3.11'
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
+gem "rack", ">= 2.2.3"
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 group :test do
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'timecop'
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -267,6 +268,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   tzinfo-data
   unsplash
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (4.0.5)
     puma (3.12.6)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -258,6 +258,7 @@ DEPENDENCIES
   pry
   pry-rails
   puma (~> 3.11)
+  rack (>= 2.2.3)
   rails (~> 5.2.4, >= 5.2.4.2)
   rspec-rails (~> 3.5)
   rubocop

--- a/spec/api/v1/roadtrip_request_spec.rb
+++ b/spec/api/v1/roadtrip_request_spec.rb
@@ -8,6 +8,8 @@ describe "API V1" do
       @api_key = json[:data][:attributes][:api_key]
     end
     it "returns travel time and arrival forecast", :vcr do
+      new_time = Time.at(1591722000)
+      Timecop.freeze(new_time)
       params = { origin: "Denver,CO",
                  destination: "Pueblo,CO",
                  api_key: @api_key }
@@ -26,6 +28,8 @@ describe "API V1" do
       expect(data[:destination]).to eq 'Pueblo,CO'
     end
     it "returns travel time and arrival forecast for denver to aurora", :vcr do
+      new_time = Time.at(1591722000)
+      Timecop.freeze(new_time)
       params = { origin: "Denver,CO",
                  destination: "Aurora,CO",
                  api_key: @api_key }

--- a/spec/poros/trip_spec.rb
+++ b/spec/poros/trip_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Trip, type: :model do
   end
   describe 'instance methods' do
     it '#arrival_forecast', :vcr do
+      new_time = Time.at(1591722000)
+      Timecop.freeze(new_time)
+
       info = { id: '',
                origin: 'Denver,CO',
                destination: 'Pueblo,CO',


### PR DESCRIPTION
## What functionality does this accomplish?
- Fix testing that relied on Time.now and fixture files

## Testing
### RSpec: 32 examples, 0 failures
### SimpleCov Coverage: 100.0%
### Rubocop:
- [x] No offenses
- [] Offenses (number of offenses: _ )
## Resources:
- https://github.com/travisjeffery/timecop